### PR TITLE
README.md installation example does not correctly parse browser_download_url.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ In case you are not up-to-date, please read [Apple](https://support.apple.com/en
 ## Installation
 **purge-nvda.sh** auto-manages itself and provides multiple installation and recovery options. Once the **pre-requisites** are satisfied, install the script by running the following in **Terminal**:
 ```bash
-curl -q -s "https://api.github.com/repos/mayankk2308/purge-nvda/releases/latest" | grep '"browser_download_url":' | sed -E 's/.*"([^"]+)".*/\1/' | xargs curl -L -s -0 > purge-nvda.sh && chmod +x purge-nvda.sh && ./purge-nvda.sh && rm purge-nvda.sh
+curl -q -s "https://api.github.com/repos/mayankk2308/purge-nvda/releases/latest" | grep '"browser_download_url":' | sed -E 's/.*"browser_download_url":[ \t]*"([^"]+)".*/\1/' | xargs curl -L -s -0 > purge-nvda.sh && chmod +x purge-nvda.sh && ./purge-nvda.sh && rm purge-nvda.sh
 ```
 
 For future use, only the following will be required:

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ In case you are not up-to-date, please read [Apple](https://support.apple.com/en
 ## Installation
 **purge-nvda.sh** auto-manages itself and provides multiple installation and recovery options. Once the **pre-requisites** are satisfied, install the script by running the following in **Terminal**:
 ```bash
-curl -s "https://api.github.com/repos/mayankk2308/purge-nvda/releases/latest" | grep '"browser_download_url":' | sed -E 's/.*"([^"]+)".*/\1/' | xargs curl -L -s -0 > purge-nvda.sh && chmod +x purge-nvda.sh && ./purge-nvda.sh && rm purge-nvda.sh
+curl -q -s "https://api.github.com/repos/mayankk2308/purge-nvda/releases/latest" | grep '"browser_download_url":' | sed -E 's/.*"([^"]+)".*/\1/' | xargs curl -L -s -0 > purge-nvda.sh && chmod +x purge-nvda.sh && ./purge-nvda.sh && rm purge-nvda.sh
 ```
 
 For future use, only the following will be required:


### PR DESCRIPTION
# Pull Request

### Problem(s)
The contents of the ~/.curlrc file may specify a user-agent which causes the server to return a single-line JSON response, as opposed to a multi-line response.

Specifically, specifying the following user-agent will exhibit the problem (single-line response):

```
# Disguise as IE 9 on Windows 7.
user-agent = "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)"
```

### Changes
Add the '-q' option to curl to explicitly ignore the ~/.curlrc file.  Fix up the regex for finding browser_download_url to handle both multiline and single-line responses from the server.
